### PR TITLE
changed R^2 to R² in metadata

### DIFF
--- a/Proofs/mvn-ltt.md
+++ b/Proofs/mvn-ltt.md
@@ -33,13 +33,13 @@ username: "JoramSoch"
 **Theorem:** Let $x$ follow a multivariate normal distribution:
 
 $$ \label{eq:mvn}
-x \sim \mathrm{N}(\mu, \Sigma) \; .
+x \sim \mathcal{N}(\mu, \Sigma) \; .
 $$
 
 Then, any linear transformation of $x$ is also multivariate normally distributed:
 
 $$ \label{eq:mvn-lt}
-y = Ax + b \sim \mathrm{N}(A\mu + b, A \Sigma A^T) \; .
+y = Ax + b \sim \mathcal{N}(A\mu + b, A \Sigma A^T) \; .
 $$
 
 

--- a/Proofs/rsq-der.md
+++ b/Proofs/rsq-der.md
@@ -7,11 +7,11 @@ affiliation: "BCCN Berlin"
 e_mail: "joram.soch@bccn-berlin.de"
 date: 2019-12-06 11:19:00
 
-title: "Derivation of R^2 and adjusted R^2"
+title: "Derivation of R² and adjusted R²"
 chapter: "Model Selection"
 section: "Goodness-of-fit measures"
 topic: "R-squared"
-theorem: "Derivation of R^2 and adjusted R^2"
+theorem: "Derivation of R² and adjusted R²"
 
 dependencies:
   - theorem: "ordinary least squares for multiple linear regression"


### PR DESCRIPTION
Unicode is universally supported these days, so we can do away with all this ^ uglyness. :)