### PR TITLE
remove new line in ToC

### DIFF
--- a/I/ToC.md
+++ b/I/ToC.md
@@ -424,7 +424,7 @@ title: "Table of Contents"
    &emsp;&ensp; 3.6.2. **[Probability density function](/P/lognorm-pdf)** <br>
    &emsp;&ensp; 3.6.3. **[Cumulative distribution function](/P/lognorm-cdf)** <br>
    &emsp;&ensp; 3.6.4. **[Quantile Function](/P/lognorm-qf)** <br>
-   &emsp;&ensp; 3.6.5. **[Mean](/P/lognorm-mean)** <br>   
+   &emsp;&ensp; 3.6.5. **[Mean](/P/lognorm-mean)** <br>
    &emsp;&ensp; 3.6.6. **[Median](/P/lognorm-med)** <br>
    &emsp;&ensp; 3.6.7. **[Mode](/P/lognorm-mode)** <br>
    &emsp;&ensp; 3.6.8. **[Variance](/P/lognorm-var)** <br>

--- a/P/lognorm-cdf.md
+++ b/P/lognorm-cdf.md
@@ -66,7 +66,7 @@ From this point forward, the proof is similar to the derivation of the [cumulati
 
 $$ \label{eq:lognorm-cdf-s2}
 \begin{split}
-F_X(x) &= \frac{1}{\sigma \sqrt{2 \pi}} \int_{(-\infty-\mu)/(\sqrt{2} \sigma)}^{(\ln x-\mu)/(\sqrt{2} \sigma)} \frac{1}{\exp( \sqrt{2} \sigma t + \mu)} \cdot \exp \left(-t^2 \right) \, \mathrm{d} \left( \exp \left( \sqrt{2} \sigma t + \mu \right) \right) \\
+F_X(x) &= \frac{1}{\sigma \sqrt{2 \pi}} \int_{(-\infty-\mu)/(\sqrt{2} \sigma)}^{(\ln x-\mu)/(\sqrt{2} \sigma)} \frac{1}{\exp( \sqrt{2} \sigma t + \mu)} \cdot \exp \left(-t^2 \right) \, \mathrm{d} \left[ \exp \left( \sqrt{2} \sigma t + \mu \right) \right] \\
 &=\frac{\sqrt{2} \sigma}{\sigma \sqrt{2 \pi}} \int_{-\infty}^{\frac{\ln x-\mu}{\sqrt{2} \sigma}} \frac{1}{\exp( \sqrt{2} \sigma t + \mu)} \cdot
 \exp(-t^2) \cdot \exp \left( \sqrt{2} \sigma t + \mu \right) \, \mathrm{d}t  \\
 &= \frac{1}{\sqrt{\pi}} \int_{-\infty}^{\frac{\ln x-\mu}{\sqrt{2} \sigma}} \exp(-t^2) \, \mathrm{d}t \\


### PR DESCRIPTION
It looks like some of the cosmetic changes have introduced a new line in the log-normal part of the ToC, see below: 

<img src="https://user-images.githubusercontent.com/29836439/194765767-09126873-bb38-45e3-b41e-40b30c50f9c1.png" alt="drawing" width="250"/>

attempted to fix it and added a small cosmetic  bracket change to the log-normalcdf proof.