### PR TITLE
Weak law correction

### DIFF
--- a/P/mean-wlln.md
+++ b/P/mean-wlln.md
@@ -109,5 +109,5 @@ $$
 Since $1 \leq \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right)$ for any $X$, this implies that: 
 
 $$
-\lim_{n \rightarrow \infty} \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) = 1.
+\lim_{n \rightarrow \infty} \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) = 1 \; .
 $$

--- a/P/mean-wlln.md
+++ b/P/mean-wlln.md
@@ -74,15 +74,15 @@ $$
 [Chebyshev's inequality](/P/cheb-ineq) makes a statement about a random variable $X$ in relation to its mean and variance for any positive number $x > 0$:
 
 $$ \label{eq:cheb-ineq}
-\mathrm{Pr}\left( \left| X - \mathrm{E}(\bar{X}) \right| \geq x \right) \le \frac{\mathrm{Var}(X)}{x^2} \; .
+\mathrm{Pr}\left( \left| X - \mathrm{E}(\bar{X}) \right| \geq x \right) \leq \frac{\mathrm{Var}(X)}{x^2} \; .
 $$
 
 Applying this inequality to the [random variable](/D/rvar) $\bar{X}$, we have:
 
 $$ \label{eq:mean-wlln-s1}
 \begin{split}
-\mathrm{Pr}\left( \left| \bar{X} - \mathrm{E}(\bar{X}) \right| \geq x \right) &\le \frac{\mathrm{Var}(\bar{X})}{x^2} \\
-\mathrm{Pr}\left( \left| \bar{X} - \mu \right| \geq \epsilon \right) &le \frac{\sigma^2}{n \epsilon} \; .
+\mathrm{Pr}\left( \left| \bar{X} - \mathrm{E}(\bar{X}) \right| \geq x \right) &\leq \frac{\mathrm{Var}(\bar{X})}{x^2} \\
+\mathrm{Pr}\left( \left| \bar{X} - \mu \right| \geq \epsilon \right) &\leq \frac{\sigma^2}{n \epsilon} \; .
 \end{split}
 $$
 
@@ -90,8 +90,8 @@ Since [the cumulative distribution function can be used to relate probabilities 
 
 $$ \label{eq:mean-wlln-s2}
 \begin{split}
-1 - \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &\le \frac{\sigma^2}{n \epsilon} \\
-\mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &\ge 1 - \frac{\sigma^2}{n \epsilon} \; .
+1 - \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &\leq \frac{\sigma^2}{n \epsilon} \\
+\mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &\geq 1 - \frac{\sigma^2}{n \epsilon} \; .
 \end{split}
 $$
 
@@ -100,8 +100,8 @@ Now taking the limit for $n \rightarrow \infty$ on both sides, while considering
 $$ \label{eq:mean-wlln-s3}
 \begin{split}
 \lim_{n \rightarrow \infty} \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right)
-&\ge \lim_{n \rightarrow \infty} \left( 1 - \frac{\sigma^2}{n \epsilon} \right) \\
-&\ge 1 - \lim_{n \rightarrow \infty} \frac{\sigma^2 / \epsilon}{n} \\
-&\ge 1 \; .
+&\geq \lim_{n \rightarrow \infty} \left( 1 - \frac{\sigma^2}{n \epsilon} \right) \\
+&\geq 1 - \lim_{n \rightarrow \infty} \frac{\sigma^2 / \epsilon}{n} \\
+&\geq 1 \; .
 \end{split}
 $$

--- a/P/mean-wlln.md
+++ b/P/mean-wlln.md
@@ -102,7 +102,7 @@ $$ \label{eq:mean-wlln-s3}
 \lim_{n \rightarrow \infty} \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right)
 &\geq \lim_{n \rightarrow \infty} \left( 1 - \frac{\sigma^2}{n \epsilon} \right) \\
 &\geq 1 - \lim_{n \rightarrow \infty} \frac{\sigma^2 / \epsilon}{n} \\
-&geq 1 \; .
+&\geq 1 \; .
 \end{split}
 $$
 

--- a/P/mean-wlln.md
+++ b/P/mean-wlln.md
@@ -102,6 +102,12 @@ $$ \label{eq:mean-wlln-s3}
 \lim_{n \rightarrow \infty} \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right)
 &\geq \lim_{n \rightarrow \infty} \left( 1 - \frac{\sigma^2}{n \epsilon} \right) \\
 &\geq 1 - \lim_{n \rightarrow \infty} \frac{\sigma^2 / \epsilon}{n} \\
-&\geq 1 \; .
+&geq 1 \; .
 \end{split}
+$$
+
+Since $1 \leq \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right)$ for any $X$, this implies that: 
+
+$$
+\lim_{n \rightarrow \infty} \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) = 1.
 $$

--- a/P/mean-wlln.md
+++ b/P/mean-wlln.md
@@ -74,15 +74,15 @@ $$
 [Chebyshev's inequality](/P/cheb-ineq) makes a statement about a random variable $X$ in relation to its mean and variance for any positive number $x > 0$:
 
 $$ \label{eq:cheb-ineq}
-\mathrm{Pr}\left( \left| X - \mathrm{E}(\bar{X}) \right| \geq x \right) = \frac{\mathrm{Var}(X)}{x} \; .
+\mathrm{Pr}\left( \left| X - \mathrm{E}(\bar{X}) \right| \geq x \right) le \frac{\mathrm{Var}(X)}{x^2} \; .
 $$
 
 Applying this inequality to the [random variable](/D/rvar) $\bar{X}$, we have:
 
 $$ \label{eq:mean-wlln-s1}
 \begin{split}
-\mathrm{Pr}\left( \left| \bar{X} - \mathrm{E}(\bar{X}) \right| \geq x \right) &= \frac{\mathrm{Var}(\bar{X})}{x} \\
-\mathrm{Pr}\left( \left| \bar{X} - \mu \right| \geq \epsilon \right) &= \frac{\sigma^2}{n \epsilon} \; .
+\mathrm{Pr}\left( \left| \bar{X} - \mathrm{E}(\bar{X}) \right| \geq x \right) &\le \frac{\mathrm{Var}(\bar{X})}{x^2} \\
+\mathrm{Pr}\left( \left| \bar{X} - \mu \right| \geq \epsilon \right) &le \frac{\sigma^2}{n \epsilon} \; .
 \end{split}
 $$
 
@@ -90,8 +90,8 @@ Since [the cumulative distribution function can be used to relate probabilities 
 
 $$ \label{eq:mean-wlln-s2}
 \begin{split}
-1 - \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &= \frac{\sigma^2}{n \epsilon} \\
-\mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &= 1 - \frac{\sigma^2}{n \epsilon} \; .
+1 - \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &le \frac{\sigma^2}{n \epsilon} \\
+\mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &ge 1 - \frac{\sigma^2}{n \epsilon} \; .
 \end{split}
 $$
 
@@ -100,8 +100,8 @@ Now taking the limit for $n \rightarrow \infty$ on both sides, while considering
 $$ \label{eq:mean-wlln-s3}
 \begin{split}
 \lim_{n \rightarrow \infty} \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right)
-&= \lim_{n \rightarrow \infty} \left( 1 - \frac{\sigma^2}{n \epsilon} \right) \\
-&= 1 - \lim_{n \rightarrow \infty} \frac{\sigma^2 / \epsilon}{n} \\
-&= 1 \; .
+&ge \lim_{n \rightarrow \infty} \left( 1 - \frac{\sigma^2}{n \epsilon} \right) \\
+&ge 1 - \lim_{n \rightarrow \infty} \frac{\sigma^2 / \epsilon}{n} \\
+&ge 1 \; .
 \end{split}
 $$

--- a/P/mean-wlln.md
+++ b/P/mean-wlln.md
@@ -74,7 +74,7 @@ $$
 [Chebyshev's inequality](/P/cheb-ineq) makes a statement about a random variable $X$ in relation to its mean and variance for any positive number $x > 0$:
 
 $$ \label{eq:cheb-ineq}
-\mathrm{Pr}\left( \left| X - \mathrm{E}(\bar{X}) \right| \geq x \right) le \frac{\mathrm{Var}(X)}{x^2} \; .
+\mathrm{Pr}\left( \left| X - \mathrm{E}(\bar{X}) \right| \geq x \right) \le \frac{\mathrm{Var}(X)}{x^2} \; .
 $$
 
 Applying this inequality to the [random variable](/D/rvar) $\bar{X}$, we have:
@@ -90,8 +90,8 @@ Since [the cumulative distribution function can be used to relate probabilities 
 
 $$ \label{eq:mean-wlln-s2}
 \begin{split}
-1 - \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &le \frac{\sigma^2}{n \epsilon} \\
-\mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &ge 1 - \frac{\sigma^2}{n \epsilon} \; .
+1 - \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &\le \frac{\sigma^2}{n \epsilon} \\
+\mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right) &\ge 1 - \frac{\sigma^2}{n \epsilon} \; .
 \end{split}
 $$
 
@@ -100,8 +100,8 @@ Now taking the limit for $n \rightarrow \infty$ on both sides, while considering
 $$ \label{eq:mean-wlln-s3}
 \begin{split}
 \lim_{n \rightarrow \infty} \mathrm{Pr}\left( \left| \bar{X} - \mu \right| < \epsilon \right)
-&ge \lim_{n \rightarrow \infty} \left( 1 - \frac{\sigma^2}{n \epsilon} \right) \\
-&ge 1 - \lim_{n \rightarrow \infty} \frac{\sigma^2 / \epsilon}{n} \\
-&ge 1 \; .
+&\ge \lim_{n \rightarrow \infty} \left( 1 - \frac{\sigma^2}{n \epsilon} \right) \\
+&\ge 1 - \lim_{n \rightarrow \infty} \frac{\sigma^2 / \epsilon}{n} \\
+&\ge 1 \; .
 \end{split}
 $$


### PR DESCRIPTION
In the Weak Law of Large Numbers (https://statproofbook.github.io/P/mean-wlln), equation 5 have $x^2$ in the denominator, rather than $x$. Both from Chebyshev's inequality, and basic unit analysis ($Var(X)/x$ should have units of $[1/x]$, which would not be a probability). Also, this should be stated as an inequality ($Pr(|X - E(\bar{X})| \ge x) \le \frac{Var(\bar{X})}{x^2}$), since Chebyshev holds for all random vars with finite variance (that bound will be much tighter if $X$ is Normally distributed). 

This should propagate through so that equation (6) should be:

$Pr(|\bar{X} - E(\bar{X})| \ge x) \le \frac{Var(\bar{X})}{x^2}$

I've updated the rest of the proof to use the right inequalities throughout. All the commits should be able to be squashed to a single one. 
