### PR TITLE
Correction in the proof: the median minimizes the mean absolute error

### DIFF
--- a/P/med-mae.md
+++ b/P/med-mae.md
@@ -65,7 +65,7 @@ Applying Leibniz's rule, we can differentiate the objective function as follows:
 $$ \label{eq:med-mae-s2}
 \begin{split}
     &\frac{\partial}{\partial a} \left( \int_{-\infty}^a (a - x) f(x) \, \mathrm{d}x + \int_{a}^\infty (x - a) f(x) \, \mathrm{d}x \right) \\
-=\; &(a - x) f(x) + \int_{-\infty}^a f(x) \, \mathrm{d}x - (x - a) f(x) - \int_{a}^\infty f(x) \, \mathrm{d}x \; .
+=\; &(a - x) f(x)\Big|_{x=a} + \int_{-\infty}^a f(x) \, \mathrm{d}x - (x - a) f(x)\Big|_{x=a} - \int_{a}^\infty f(x) \, \mathrm{d}x \; .
 \end{split}
 $$
 


### PR DESCRIPTION
In this part of the proof
![image](https://github.com/user-attachments/assets/fd8887d4-c74c-40c3-9381-f248d4d441c0)
It is suggested that the terms (a-x)f(x) and (x-a)f(x) cancell each other out when in reality the terms are cancelled due to leinbiz rule
![image](https://github.com/user-attachments/assets/3f7cb886-aec4-4b3b-9815-98ecb2104719)
since (a-a)f(a) = 0