### PR TITLE
Dynamic ToC compilation based on `book_content.md`

### DIFF
--- a/I/ToC.md
+++ b/I/ToC.md
@@ -5,7 +5,7 @@ title: "Table of Contents"
 
 
 **[Proofs](/P/-temp-)** are printed in **bold** – *[Definitions](/D/-temp-)* are set in *italics* <br>
-**Proofs**: [by Number](/I/PbN), [by Topic](/I/PbT) – *Definitions*:  [by Number](/I/DbN), [by Topic](/D/DbT) <br>
+**Proofs**: [by Number](/I/PbN), [by Topic](/I/PbT) – *Definitions*:  [by Number](/I/DbN), [by Topic](/I/DbT) <br>
 <u>Specials:</u> [General Theorems](/S/ChI), [Probability Distributions](/S/ChII), [Statistical Models](/S/ChIII), [Model Selection Criteria](/S/ChIV) <br>
 
 

--- a/I/ToC.md
+++ b/I/ToC.md
@@ -5,13 +5,14 @@ title: "Table of Contents"
 
 
 **[Proofs](/P/-temp-)** are printed in **bold** – *[Definitions](/D/-temp-)* are set in *italics* <br>
-**Proofs**: [by Number](/I/PbN), [by Topic](/I/PbT) – *Definitions*:  [by Number](/I/DbN), [by Topic](/I/DbT) <br>
+**Proofs**: [by Number](/I/PbN), [by Topic](/I/PbT) – *Definitions*:  [by Number](/I/DbN), [by Topic](/D/DbT) <br>
 <u>Specials:</u> [General Theorems](/S/ChI), [Probability Distributions](/S/ChII), [Statistical Models](/S/ChIII), [Model Selection Criteria](/S/ChIV) <br>
 
 
 <br>
 <h3 id="General Theorems">Chapter I: General Theorems</h3>
 
+   
 1. <p id="Probability theory">Probability theory</p>
    
    <p id="Random experiments"></p>
@@ -110,10 +111,10 @@ title: "Table of Contents"
    &emsp;&ensp; 1.8.5. **[Cumulative distribution function of discrete random variable](/P/cdf-pmf)** <br>
    &emsp;&ensp; 1.8.6. **[Cumulative distribution function of continuous random variable](/P/cdf-pdf)** <br>
    &emsp;&ensp; 1.8.7. **[Exceedance probability based on cumulative distribution function](/P/cdf-probexc)** <br>
-   &emsp;&ensp; 1.8.7. **[Probability integral transform](/P/cdf-pit)** <br>
-   &emsp;&ensp; 1.8.8. **[Inverse transformation method](/P/cdf-itm)** <br>
-   &emsp;&ensp; 1.8.9. **[Distributional transformation](/P/cdf-dt)** <br>
-   &emsp;&ensp; 1.8.10. *[Joint cumulative distribution function](/D/cdf-joint)* <br>
+   &emsp;&ensp; 1.8.8. **[Probability integral transform](/P/cdf-pit)** <br>
+   &emsp;&ensp; 1.8.9. **[Inverse transformation method](/P/cdf-itm)** <br>
+   &emsp;&ensp; 1.8.10. **[Distributional transformation](/P/cdf-dt)** <br>
+   &emsp;&ensp; 1.8.11. *[Joint cumulative distribution function](/D/cdf-joint)* <br>
    
    <p id="Moment-generating function"></p>
    1.9. Moment-generating function <br>
@@ -166,16 +167,16 @@ title: "Table of Contents"
    &emsp;&ensp; 1.13.1. *[Definition](/D/var)* <br>
    &emsp;&ensp; 1.13.2. *[Sample variance](/D/var-samp)* <br>
    &emsp;&ensp; 1.13.3. *[Pooled sample variance](/D/var-pool)* <br>
-   &emsp;&ensp; 1.13.3. **[Partition into expected values](/P/var-mean)** <br>
-   &emsp;&ensp; 1.13.4. **[Non-negativity](/P/var-nonneg)** <br>
-   &emsp;&ensp; 1.13.5. **[Variance of a constant](/P/var-const)** <br>
-   &emsp;&ensp; 1.13.6. **[Invariance under addition](/P/var-inv)** <br>
-   &emsp;&ensp; 1.13.7. **[Scaling upon multiplication](/P/var-scal)** <br>
-   &emsp;&ensp; 1.13.8. **[Variance of a sum](/P/var-sum)** <br>
-   &emsp;&ensp; 1.13.9. **[Variance of linear combination](/P/var-lincomb)** <br>
-   &emsp;&ensp; 1.13.10. **[Additivity under independence](/P/var-add)** <br>
-   &emsp;&ensp; 1.13.11. **[Law of total variance](/P/var-tot)** <br>
-   &emsp;&ensp; 1.13.12. *[Precision](/D/prec)* <br>
+   &emsp;&ensp; 1.13.4. **[Partition into expected values](/P/var-mean)** <br>
+   &emsp;&ensp; 1.13.5. **[Non-negativity](/P/var-nonneg)** <br>
+   &emsp;&ensp; 1.13.6. **[Variance of a constant](/P/var-const)** <br>
+   &emsp;&ensp; 1.13.7. **[Invariance under addition](/P/var-inv)** <br>
+   &emsp;&ensp; 1.13.8. **[Scaling upon multiplication](/P/var-scal)** <br>
+   &emsp;&ensp; 1.13.9. **[Variance of a sum](/P/var-sum)** <br>
+   &emsp;&ensp; 1.13.10. **[Variance of linear combination](/P/var-lincomb)** <br>
+   &emsp;&ensp; 1.13.11. **[Additivity under independence](/P/var-add)** <br>
+   &emsp;&ensp; 1.13.12. **[Law of total variance](/P/var-tot)** <br>
+   &emsp;&ensp; 1.13.13. *[Precision](/D/prec)* <br>
    
    <p id="Skewness"></p>
    1.14. Skewness <br>
@@ -249,7 +250,7 @@ title: "Table of Contents"
    &emsp;&ensp; 1.21.7. **[First central moment is zero](/P/momcent-1st)** <br>
    &emsp;&ensp; 1.21.8. **[Second central moment is variance](/P/momcent-2nd)** <br>
    &emsp;&ensp; 1.21.9. *[Standardized moment](/D/mom-stand)* <br>
-
+   
 2. <p id="Information theory">Information theory</p>
    
    <p id="Shannon entropy"></p>
@@ -302,7 +303,7 @@ title: "Table of Contents"
    &emsp;&ensp; 2.5.8. **[Invariance under parameter transformation](/P/kl-inv)** <br>
    &emsp;&ensp; 2.5.9. **[Relation to discrete entropy](/P/kl-ent)** <br>
    &emsp;&ensp; 2.5.10. **[Relation to differential entropy](/P/kl-dent)** <br>
-
+   
 3. <p id="Estimation theory">Estimation theory</p>
    
    <p id="Basic concepts of estimation"></p>
@@ -319,7 +320,7 @@ title: "Table of Contents"
    3.3. Interval estimates <br>
    &emsp;&ensp; 3.3.1. *[Confidence interval](/D/ci)* <br>
    &emsp;&ensp; 3.3.2. **[Construction of confidence intervals using Wilks' theorem](/P/ci-wilks)** <br>
-
+   
 4. <p id="Frequentist statistics">Frequentist statistics</p>
    
    <p id="Likelihood theory"></p>
@@ -355,7 +356,7 @@ title: "Table of Contents"
    &emsp;&ensp; 4.3.11. **[Distribution of p-value under null hypothesis](/P/pval-h0)** <br>
    &emsp;&ensp; 4.3.12. *[Minimum detectable effect](/D/mde)* <br>
    &emsp;&ensp; 4.3.13. *[Minimum required sample size](/D/mrss)* <br>
-
+   
 5. <p id="Bayesian statistics">Bayesian statistics</p>
    
    <p id="Probabilistic modeling"></p>
@@ -397,7 +398,7 @@ title: "Table of Contents"
    &emsp;&ensp; 5.3.5. *[Variational Bayes](/D/vb)* <br>
    &emsp;&ensp; 5.3.6. **[Decomposition of the free energy](/P/fren-dec)** <br>
    &emsp;&ensp; 5.3.7. **[Free energy is lower bound on log model evidence](/P/fren-lme)** <br>
-
+   
 6. <p id="Machine learning">Machine learning</p>
    
    <p id="Scoring rules"></p>
@@ -414,6 +415,7 @@ title: "Table of Contents"
 <br>
 <h3 id="Probability Distributions">Chapter II: Probability Distributions</h3>
 
+   
 1. <p id="Univariate discrete distributions">Univariate discrete distributions</p>
    
    <p id="Discrete uniform distribution"></p>
@@ -465,7 +467,7 @@ title: "Table of Contents"
    &emsp;&ensp; 1.5.3. **[Mean](/P/poiss-mean)** <br>
    &emsp;&ensp; 1.5.4. **[Variance](/P/poiss-var)** <br>
    &emsp;&ensp; 1.5.5. **[Shannon entropy](/P/poiss-ent)** <br>
-
+   
 2. <p id="Multivariate discrete distributions">Multivariate discrete distributions</p>
    
    <p id="Categorical distribution"></p>
@@ -485,7 +487,7 @@ title: "Table of Contents"
    &emsp;&ensp; 2.2.5. **[Covariance](/P/mult-cov)** <br>
    &emsp;&ensp; 2.2.6. **[Shannon entropy](/P/mult-ent)** <br>
    &emsp;&ensp; 2.2.7. **[Marginal distributions](/P/mult-marg)** <br>
-
+   
 3. <p id="Univariate continuous distributions">Univariate continuous distributions</p>
    
    <p id="Continuous uniform distribution"></p>
@@ -635,7 +637,7 @@ title: "Table of Contents"
    &emsp;&ensp; 3.11.5. **[Variance](/P/exg-var)** <br>
    &emsp;&ensp; 3.11.6. **[Skewness](/P/exg-skew)** <br>
    &emsp;&ensp; 3.11.7. **[Method of moments](/P/exg-mome)** <br>
-
+   
 4. <p id="Multivariate continuous distributions">Multivariate continuous distributions</p>
    
    <p id="Multivariate normal distribution"></p>
@@ -694,7 +696,7 @@ title: "Table of Contents"
    &emsp;&ensp; 4.5.2. **[Probability density function](/P/dir-pdf)** <br>
    &emsp;&ensp; 4.5.3. **[Kullback-Leibler divergence](/P/dir-kl)** <br>
    &emsp;&ensp; 4.5.4. **[Exceedance probabilities](/P/dir-ep)** <br>
-
+   
 5. <p id="Matrix-variate continuous distributions">Matrix-variate continuous distributions</p>
    
    <p id="Matrix-normal distribution"></p>
@@ -728,6 +730,7 @@ title: "Table of Contents"
 <br>
 <h3 id="Statistical Models">Chapter III: Statistical Models</h3>
 
+   
 1. <p id="Univariate normal data">Univariate normal data</p>
    
    <p id="Univariate Gaussian"></p>
@@ -872,7 +875,7 @@ title: "Table of Contents"
    &emsp;&ensp; 1.7.4. **[Accuracy and complexity](/P/blrkc-anc)** <br>
    
 2. <p id="Multivariate normal data">Multivariate normal data</p>
-
+   
    <p id="Multivariate Gaussian"></p>
    2.1. Multivariate Gaussian <br>
    &emsp;&ensp; 2.1.1. *[Bivariate normally distributed data](/D/bvn-data)* <br>
@@ -912,7 +915,7 @@ title: "Table of Contents"
    &emsp;&ensp; 2.5.1. **[Conjugate prior distribution](/P/mblr-prior)** <br>
    &emsp;&ensp; 2.5.2. **[Posterior distribution](/P/mblr-post)** <br>
    &emsp;&ensp; 2.5.3. **[Log model evidence](/P/mblr-lme)** <br>
-
+   
 3. <p id="Count data">Count data</p>
    
    <p id="Binomial observations"></p>
@@ -958,7 +961,7 @@ title: "Table of Contents"
    &emsp;&ensp; 3.4.3. **[Conjugate prior distribution](/P/poissexp-prior)** <br>
    &emsp;&ensp; 3.4.4. **[Posterior distribution](/P/poissexp-post)** <br>
    &emsp;&ensp; 3.4.5. **[Log model evidence](/P/poissexp-lme)** <br>
-
+   
 4. <p id="Frequency data">Frequency data</p>
    
    <p id="Beta-distributed data"></p>
@@ -975,7 +978,7 @@ title: "Table of Contents"
    4.3. Beta-binomial data <br>
    &emsp;&ensp; 4.3.1. *[Definition](/D/betabin-data)* <br>
    &emsp;&ensp; 4.3.2. **[Method of moments](/P/betabin-mome)** <br>
-
+   
 5. <p id="Categorical data">Categorical data</p>
    
    <p id="Logistic regression"></p>
@@ -988,6 +991,7 @@ title: "Table of Contents"
 <br>
 <h3 id="Model Selection">Chapter IV: Model Selection</h3>
 
+   
 1. <p id="Goodness-of-fit measures">Goodness-of-fit measures</p>
    
    <p id="Residual variance"></p>
@@ -1020,7 +1024,7 @@ title: "Table of Contents"
    &emsp;&ensp; 1.4.1. *[Definition](/D/snr)* <br>
    &emsp;&ensp; 1.4.2. **[Relationship to coefficient of determination](/P/snr-rsq)** <br>
    &emsp;&ensp; 1.4.3. **[Relationship to maximum log-likelihood](/P/snr-mll)** <br>
-
+   
 2. <p id="Classical information criteria">Classical information criteria</p>
    
    <p id="Akaike information criterion"></p>
@@ -1039,7 +1043,7 @@ title: "Table of Contents"
    2.3. Deviance information criterion <br>
    &emsp;&ensp; 2.3.1. *[Definition](/D/dic)* <br>
    &emsp;&ensp; 2.3.2. *[Deviance](/D/dev)* <br>
-
+   
 3. <p id="Bayesian model selection">Bayesian model selection</p>
    
    <p id="Model evidence"></p>

--- a/book_content.md
+++ b/book_content.md
@@ -1,0 +1,866 @@
+# Chapter I: General Theorems
+## Probability theory
+### Random experiments
+- *[Random experiment](/D/rexp)*
+- *[Sample space](/D/samp-spc)*
+- *[Event space](/D/eve-spc)*
+- *[Probability space](/D/prob-spc)*
+- *[Measured data](/D/data)*
+- *[Statistical sample](/D/samp)*
+- *[Sample size](/D/samp-size)*
+- *[Sample statistic](/D/stat)*
+- *[Descriptive vs. inferential](/D/stat-desc)*
+### Random variables
+- *[Random event](/D/reve)*
+- *[Random variable](/D/rvar)*
+- *[Random vector](/D/rvec)*
+- *[Random matrix](/D/rmat)*
+- *[Constant](/D/const)*
+- *[Discrete vs. continuous](/D/rvar-disc)*
+- *[Univariate vs. multivariate](/D/rvar-uni)*
+- *[independent and identically distributed](/D/iid)*
+### Probability
+- *[Probability](/D/prob)*
+- *[Joint probability](/D/prob-joint)*
+- *[Marginal probability](/D/prob-marg)*
+- *[Conditional probability](/D/prob-cond)*
+- *[Exceedance probability](/D/prob-exc)*
+- *[Statistical independence](/D/ind)*
+- *[Conditional independence](/D/ind-cond)*
+- **[Self-independence](/P/ind-self)**
+- **[Probability under independence](/P/prob-ind)**
+- *[Mutual exclusivity](/D/exc)*
+- **[Probability under exclusivity](/P/prob-exc)**
+### Probability axioms
+- *[Axioms of probability](/D/prob-ax)*
+- **[Monotonicity of probability](/P/prob-mon)**
+- **[Monotonicity of probability](/P/prob-mon2)**
+- **[Probability of the empty set](/P/prob-emp)**
+- **[Probability of the empty set](/P/prob-emp2)**
+- **[Probability of the complement](/P/prob-comp)**
+- **[Range of probability](/P/prob-range)**
+- **[Addition law of probability](/P/prob-add)**
+- **[Bonferroni's inequality](/P/bonf-ineq)**
+- **[Boole's inequality](/P/bool-ineq)**
+- **[Law of total probability](/P/prob-tot)**
+- **[Probability of exhaustive events](/P/prob-exh)**
+- **[Probability of exhaustive events](/P/prob-exh2)**
+### Probability distributions
+- *[Probability distribution](/D/dist)*
+- *[Joint distribution](/D/dist-joint)*
+- *[Marginal distribution](/D/dist-marg)*
+- *[Conditional distribution](/D/dist-cond)*
+- *[Unimodal vs. multimodal distribution](/D/dist-uni)*
+- *[Sampling distribution](/D/dist-samp)*
+- *[Statistical parameter](/D/para)*
+- *[Location parameter](/D/para-loc)*
+- *[Scale parameter](/D/para-scal)*
+- *[Rate parameter](/D/para-rate)*
+- *[Shape parameter](/D/para-shape)*
+- *[Degrees of freedom](/D/dof)*
+### Probability mass function
+- *[Definition](/D/pmf)*
+- **[Probability mass function of sum of independents](/P/pmf-sumind)**
+- **[Probability mass function of strictly increasing function](/P/pmf-sifct)**
+- **[Probability mass function of strictly decreasing function](/P/pmf-sdfct)**
+- **[Probability mass function of invertible function](/P/pmf-invfct)**
+### Probability density function
+- *[Definition](/D/pdf)*
+- **[Probability density function of sum of independents](/P/pdf-sumind)**
+- **[Probability density function of strictly increasing function](/P/pdf-sifct)**
+- **[Probability density function of strictly decreasing function](/P/pdf-sdfct)**
+- **[Probability density function of invertible function](/P/pdf-invfct)**
+- **[Probability density function of linear transformation](/P/pdf-linfct)**
+- **[Probability density function in terms of cumulative distribution function](/P/pdf-cdf)**
+- *[Joint probability density function](/D/pdf-joint)*
+### Cumulative distribution function
+- *[Definition](/D/cdf)*
+- **[Cumulative distribution function of sum of independents](/P/cdf-sumind)**
+- **[Cumulative distribution function of strictly increasing function](/P/cdf-sifct)**
+- **[Cumulative distribution function of strictly decreasing function](/P/cdf-sdfct)**
+- **[Cumulative distribution function of discrete random variable](/P/cdf-pmf)**
+- **[Cumulative distribution function of continuous random variable](/P/cdf-pdf)**
+- **[Exceedance probability based on cumulative distribution function](/P/cdf-probexc)**
+- **[Probability integral transform](/P/cdf-pit)**
+- **[Inverse transformation method](/P/cdf-itm)**
+- **[Distributional transformation](/P/cdf-dt)**
+- *[Joint cumulative distribution function](/D/cdf-joint)*
+### Moment-generating function
+- *[Definition](/D/mgf)*
+- **[Moment-generating function of sum of independents](/P/mgf-sumind)**
+- **[Moment-generating function of arbitrary function](/P/mgf-fct)**
+- **[Moment-generating function of linear transformation](/P/mgf-ltt)**
+- **[Moment-generating function of linear combination](/P/mgf-lincomb)**
+### Probability-generating function
+- *[Definition](/D/pgf)*
+- **[Probability-generating function in terms of expected value](/P/pgf-mean)**
+- **[Probability-generating function of zero](/P/pgf-zero)**
+- **[Probability-generating function of one](/P/pgf-one)**
+### Other probability functions
+- *[Quantile function](/D/qf)*
+- **[Quantile function in terms of cumulative distribution function](/P/qf-cdf)**
+- *[Characteristic function](/D/cf)*
+- **[Characteristic function of arbitrary function](/P/cf-fct)**
+- *[Cumulant-generating function](/D/cgf)*
+### Expected value
+- *[Definition](/D/mean)*
+- *[Sample mean](/D/mean-samp)*
+- **[Non-negative random variable](/P/mean-nnrvar)**
+- **[Non-negativity](/P/mean-nonneg)**
+- **[Linearity](/P/mean-lin)**
+- **[Monotonicity](/P/mean-mono)**
+- **[(Non-)Multiplicativity](/P/mean-mult)**
+- **[Law of total expectation](/P/mean-tot)**
+- **[Law of the unconscious statistician](/P/mean-lotus)**
+- **[Squared expectation of a product](/P/mean-prodsqr)**
+- **[Jensen's inequality](/P/jens-ineq)**
+- **[Markov's inequality](/P/mark-ineq)**
+- **[Chebyshev's inequality](/P/cheb-ineq)**
+- **[Weak law of large numbers](/P/mean-wlln)**
+- **[Expected value minimizes squared error](/P/mean-mse)**
+- *[Expected value of a random vector](/D/mean-rvec)*
+- **[Expectation of a quadratic form](/P/mean-qf)**
+- **[Expectation of a bilinear form](/P/mean-blf)**
+- *[Expected value of a random matrix](/D/mean-rmat)*
+- **[Expectation of a trace](/P/mean-tr)**
+### Variance
+- *[Definition](/D/var)*
+- *[Sample variance](/D/var-samp)*
+- *[Pooled sample variance](/D/var-pool)*
+- **[Partition into expected values](/P/var-mean)**
+- **[Non-negativity](/P/var-nonneg)**
+- **[Variance of a constant](/P/var-const)**
+- **[Invariance under addition](/P/var-inv)**
+- **[Scaling upon multiplication](/P/var-scal)**
+- **[Variance of a sum](/P/var-sum)**
+- **[Variance of linear combination](/P/var-lincomb)**
+- **[Additivity under independence](/P/var-add)**
+- **[Law of total variance](/P/var-tot)**
+- *[Precision](/D/prec)*
+### Skewness
+- *[Definition](/D/skew)*
+- *[Sample skewness](/D/skew-samp)*
+- **[Partition into expected values](/P/skew-mean)**
+### Covariance
+- *[Definition](/D/cov)*
+- *[Sample covariance](/D/cov-samp)*
+- **[Partition into expected values](/P/cov-mean)**
+- **[Symmetry](/P/cov-symm)**
+- **[Self-covariance](/P/cov-var)**
+- **[Covariance under independence](/P/cov-ind)**
+- **[Law of total covariance](/P/cov-tot)**
+- **[Relationship to correlation](/P/cov-corr)**
+### Covariance matrix
+- *[Definition](/D/covmat)*
+- *[Sample covariance matrix](/D/covmat-samp)*
+- **[Partition into expected values](/P/covmat-mean)**
+- **[Symmetry](/P/covmat-symm)**
+- **[Positive semi-definiteness](/P/covmat-psd)**
+- **[Invariance under addition of vector](/P/covmat-inv)**
+- **[Scaling upon multiplication with matrix](/P/covmat-scal)**
+- **[Covariance matrix and correlation matrix](/P/covmat-corrmat)**
+- *[Cross-covariance matrix](/D/covmat-cross)*
+- **[Cross-covariance and expected values](/P/covmatcross-mean)**
+- **[Covariance matrix of a sum](/P/covmat-sum)**
+- *[Precision matrix](/D/precmat)*
+- **[Precision matrix and correlation matrix](/P/precmat-corrmat)**
+### Correlation
+- *[Definition](/D/corr)*
+- **[Range](/P/corr-range)**
+- **[Correlation under independence](/P/corr-ind)**
+- *[Sample correlation coefficient](/D/corr-samp)*
+- **[Relationship to standard scores](/P/corr-z)**
+- *[Correlation matrix](/D/corrmat)*
+- *[Sample correlation matrix](/D/corrmat-samp)*
+### Measures of central tendency
+- *[Median](/D/med)*
+- **[Median minimizes mean absolute error](/P/med-mae)**
+- *[Mode](/D/mode)*
+### Measures of statistical dispersion
+- *[Standard deviation](/D/std)*
+- *[Sample standard deviation](/D/std-samp)*
+- *[Pooled sample standard deviation](/D/std-pool)*
+- *[Full width at half maximum](/D/fwhm)*
+### Further summary statistics
+- *[Minimum](/D/min)*
+- *[Maximum](/D/max)*
+### Further moments
+- *[Moment](/D/mom)*
+- **[Moment in terms of moment-generating function](/P/mom-mgf)**
+- *[Raw moment](/D/mom-raw)*
+- **[First raw moment is mean](/P/momraw-1st)**
+- **[Second raw moment and variance](/P/momraw-2nd)**
+- *[Central moment](/D/mom-cent)*
+- **[First central moment is zero](/P/momcent-1st)**
+- **[Second central moment is variance](/P/momcent-2nd)**
+- *[Standardized moment](/D/mom-stand)*
+## Information theory
+### Shannon entropy
+- *[Definition](/D/ent)*
+- **[Non-negativity](/P/ent-nonneg)**
+- **[Concavity](/P/ent-conc)**
+- *[Conditional entropy](/D/ent-cond)*
+- *[Joint entropy](/D/ent-joint)*
+- *[Cross-entropy](/D/ent-cross)*
+- **[Convexity of cross-entropy](/P/entcross-conv)**
+- **[Gibbs' inequality](/P/gibbs-ineq)**
+- **[Log sum inequality](/P/logsum-ineq)**
+### Differential entropy
+- *[Definition](/D/dent)*
+- **[Negativity](/P/dent-neg)**
+- **[Invariance under addition](/P/dent-inv)**
+- **[Addition upon multiplication](/P/dent-add)**
+- **[Addition upon matrix multiplication](/P/dent-addvec)**
+- **[Non-invariance and transformation](/P/dent-noninv)**
+- *[Conditional differential entropy](/D/dent-cond)*
+- *[Joint differential entropy](/D/dent-joint)*
+- *[Differential cross-entropy](/D/dent-cross)*
+### Discrete mutual information
+- *[Definition](/D/mi)*
+- **[Relation to marginal and conditional entropy](/P/dmi-mce)**
+- **[Relation to marginal and joint entropy](/P/dmi-mje)**
+- **[Relation to joint and conditional entropy](/P/dmi-jce)**
+### Continuous mutual information
+- *[Definition](/D/mi)*
+- **[Relation to marginal and conditional differential entropy](/P/cmi-mcde)**
+- **[Relation to marginal and joint differential entropy](/P/cmi-mjde)**
+- **[Relation to joint and conditional differential entropy](/P/cmi-jcde)**
+### Kullback-Leibler divergence
+- *[Definition](/D/kl)*
+- **[Non-negativity](/P/kl-nonneg)**
+- **[Non-negativity](/P/kl-nonneg2)**
+- **[Non-negativity](/P/kl-nonneg3)**
+- **[Non-symmetry](/P/kl-nonsymm)**
+- **[Convexity](/P/kl-conv)**
+- **[Additivity for independent distributions](/P/kl-add)**
+- **[Invariance under parameter transformation](/P/kl-inv)**
+- **[Relation to discrete entropy](/P/kl-ent)**
+- **[Relation to differential entropy](/P/kl-dent)**
+## Estimation theory
+### Basic concepts of estimation
+- *[Estimator](/D/est)*
+- *[Biased vs. unbiased](/D/est-bias)*
+### Point estimates
+- *[Mean squared error](/D/mse)*
+- **[Partition of the mean squared error into bias and variance](/P/mse-bnv)**
+### Interval estimates
+- *[Confidence interval](/D/ci)*
+- **[Construction of confidence intervals using Wilks' theorem](/P/ci-wilks)**
+## Frequentist statistics
+### Likelihood theory
+- *[Likelihood function](/D/lf)*
+- *[Log-likelihood function](/D/llf)*
+- *[Maximum likelihood estimation](/D/mle)*
+- *[Maximum log-likelihood](/D/mll)*
+- **[MLE can be biased](/P/mle-bias)**
+- *[Likelihood ratio](/D/lr)*
+- *[Log-likelihood ratio](/D/llr)*
+- *[Method of moments](/D/mome)*
+### Statistical hypotheses
+- *[Statistical hypothesis](/D/hyp)*
+- *[Simple vs. composite](/D/hyp-simp)*
+- *[Point/exact vs. set/inexact](/D/hyp-point)*
+- *[One-tailed vs. two-tailed](/D/hyp-tail)*
+### Hypothesis testing
+- *[Statistical test](/D/test)*
+- *[Null hypothesis](/D/h0)*
+- *[Alternative hypothesis](/D/h1)*
+- *[One-tailed vs. two-tailed](/D/test-tail)*
+- *[Test statistic](/D/tstat)*
+- *[Size of a test](/D/size)*
+- *[Power of a test](/D/power)*
+- *[Significance level](/D/alpha)*
+- *[Critical value](/D/cval)*
+- *[p-value](/D/pval)*
+- **[Distribution of p-value under null hypothesis](/P/pval-h0)**
+- *[Minimum detectable effect](/D/mde)*
+- *[Minimum required sample size](/D/mrss)*
+## Bayesian statistics
+### Probabilistic modeling
+- *[Generative model](/D/gm)*
+- *[Likelihood function](/D/lf)*
+- *[Prior distribution](/D/prior)*
+- *[Prior predictive distribution](/D/prior-pred)*
+- **[Prior predictive distribution is marginal of joint likelihood](/P/priorpred-jl)**
+- *[Full probability model](/D/fpm)*
+- *[Joint likelihood](/D/jl)*
+- **[Joint likelihood is product of likelihood and prior](/P/jl-lfnprior)**
+- *[Posterior distribution](/D/post)*
+- **[Posterior density is proportional to joint likelihood](/P/post-jl)**
+- **[Combined posterior distribution from independent data](/P/post-ind)**
+- *[Posterior predictive distribution](/D/post-pred)*
+- **[Posterior predictive distribution is marginal of joint likelihood](/P/postpred-jl)**
+- *[Maximum-a-posteriori estimation](/D/map)*
+- *[Marginal likelihood](/D/ml)*
+- **[Marginal likelihood is integral of joint likelihood](/P/ml-jl)**
+### Prior distributions
+- *[Flat vs. hard vs. soft](/D/prior-flat)*
+- *[Uniform vs. non-uniform](/D/prior-uni)*
+- *[Informative vs. non-informative](/D/prior-inf)*
+- *[Empirical vs. non-empirical](/D/prior-emp)*
+- *[Conjugate vs. non-conjugate](/D/prior-conj)*
+- *[Maximum entropy priors](/D/prior-maxent)*
+- *[Empirical Bayes priors](/D/prior-eb)*
+- *[Reference priors](/D/prior-ref)*
+### Bayesian inference
+- *[Odds ratios](/D/odds)*
+- **[Bayes' theorem](/P/bayes-th)**
+- **[Bayes' rule](/P/bayes-rule)**
+- *[Empirical Bayes](/D/eb)*
+- *[Variational Bayes](/D/vb)*
+- **[Decomposition of the free energy](/P/fren-dec)**
+- **[Free energy is lower bound on log model evidence](/P/fren-lme)**
+## Machine learning
+### Scoring rules
+- *[Scoring rule](/D/sr)*
+- *[Proper scoring rule](/D/psr)*
+- *[Strictly proper scoring rule](/D/spsr)*
+- *[Log probability scoring rule](/D/lpsr)*
+- **[Log probability is strictly proper scoring rule](/P/lpsr-spsr)**
+- *[Brier scoring rule](/D/bsr)*
+- **[Brier scoring rule is strictly proper scoring rule](/P/bsr-spsr)**
+
+# Chapter II: Probability Distributions
+## Univariate discrete distributions
+### Discrete uniform distribution
+- *[Definition](/D/duni)*
+- **[Probability mass function](/P/duni-pmf)**
+- **[Cumulative distribution function](/P/duni-cdf)**
+- **[Quantile function](/P/duni-qf)**
+- **[Shannon entropy](/P/duni-ent)**
+- **[Kullback-Leibler divergence](/P/duni-kl)**
+- **[Maximum entropy distribution](/P/duni-maxent)**
+### Bernoulli distribution
+- *[Definition](/D/bern)*
+- **[Special case of categorical distribution](/P/bern-cat)**
+- **[Probability mass function](/P/bern-pmf)**
+- **[Mean](/P/bern-mean)**
+- **[Variance](/P/bern-var)**
+- **[Range of variance](/P/bern-varrange)**
+- **[Shannon entropy](/P/bern-ent)**
+- **[Kullback-Leibler divergence](/P/bern-kl)**
+### Binomial distribution
+- *[Definition](/D/bin)*
+- **[Special case of multinomial distribution](/P/bin-mult)**
+- **[Probability mass function](/P/bin-pmf)**
+- **[Cumulative distribution function](/P/bin-cdf)**
+- **[Probability-generating function](/P/bin-pgf)**
+- **[Mean](/P/bin-mean)**
+- **[Variance](/P/bin-var)**
+- **[Range of variance](/P/bin-varrange)**
+- **[Shannon entropy](/P/bin-ent)**
+- **[Kullback-Leibler divergence](/P/bin-kl)**
+- **[Conditional binomial](/P/bin-margcond)**
+### Beta-binomial distribution
+- *[Definition](/D/betabin)*
+- **[Probability mass function](/P/betabin-pmf)**
+- **[Probability mass function in terms of gamma function](/P/betabin-pmfitogf)**
+- **[Cumulative distribution function](/P/betabin-cdf)**
+### Poisson distribution
+- *[Definition](/D/poiss)*
+- **[Probability mass function](/P/poiss-pmf)**
+- **[Mean](/P/poiss-mean)**
+- **[Variance](/P/poiss-var)**
+- **[Shannon entropy](/P/poiss-ent)**
+## Multivariate discrete distributions
+### Categorical distribution
+- *[Definition](/D/cat)*
+- **[Probability mass function](/P/cat-pmf)**
+- **[Mean](/P/cat-mean)**
+- **[Covariance](/P/cat-cov)**
+- **[Shannon entropy](/P/cat-ent)**
+### Multinomial distribution
+- *[Definition](/D/mult)*
+- **[Probability mass function](/P/mult-pmf)**
+- **[Cumulative distribution function](/P/mult-cdf)**
+- **[Mean](/P/mult-mean)**
+- **[Covariance](/P/mult-cov)**
+- **[Shannon entropy](/P/mult-ent)**
+- **[Marginal distributions](/P/mult-marg)**
+## Univariate continuous distributions
+### Continuous uniform distribution
+- *[Definition](/D/cuni)*
+- *[Standard uniform distribution](/D/suni)*
+- **[Probability density function](/P/cuni-pdf)**
+- **[Cumulative distribution function](/P/cuni-cdf)**
+- **[Quantile function](/P/cuni-qf)**
+- **[Mean](/P/cuni-mean)**
+- **[Median](/P/cuni-med)**
+- **[Mode](/P/cuni-mode)**
+- **[Variance](/P/cuni-var)**
+- **[Differential entropy](/P/cuni-dent)**
+- **[Kullback-Leibler divergence](/P/cuni-kl)**
+- **[Maximum entropy distribution](/P/cuni-maxent)**
+### Normal distribution
+- *[Definition](/D/norm)*
+- **[Special case of multivariate normal distribution](/P/norm-mvn)**
+- *[Standard normal distribution](/D/snorm)*
+- **[Relationship to standard normal distribution](/P/norm-snorm)**
+- **[Relationship to standard normal distribution](/P/norm-snorm2)**
+- **[Relationship to standard normal distribution](/P/norm-snorm3)**
+- **[Relationship to chi-squared distribution](/P/norm-chi2)**
+- **[Relationship to t-distribution](/P/norm-t)**
+- **[Gaussian integral](/P/norm-gi)**
+- **[Probability density function](/P/norm-pdf)**
+- **[Moment-generating function](/P/norm-mgf)**
+- **[Cumulative distribution function](/P/norm-cdf)**
+- **[Cumulative distribution function without error function](/P/norm-cdfwerf)**
+- **[Probability of being within standard deviations from mean](/P/norm-probstd)**
+- **[Quantile function](/P/norm-qf)**
+- **[Mean](/P/norm-mean)**
+- **[Median](/P/norm-med)**
+- **[Mode](/P/norm-mode)**
+- **[Variance](/P/norm-var)**
+- **[Full width at half maximum](/P/norm-fwhm)**
+- **[Extreme points](/P/norm-extr)**
+- **[Inflection points](/P/norm-infl)**
+- **[Differential entropy](/P/norm-dent)**
+- **[Kullback-Leibler divergence](/P/norm-kl)**
+- **[Maximum entropy distribution](/P/norm-maxent)**
+- **[Linear combination of independent normals](/P/norm-lincomb)**
+- **[Normal and uncorrelated does not imply independent](/P/norm-corrind)**
+- **[Marginally normal does not imply jointly normal](/P/norm-margjoint)**
+### t-distribution
+- *[Definition](/D/t)*
+- **[Special case of multivariate t-distribution](/P/t-mvt)**
+- *[Non-standardized t-distribution](/D/nst)*
+- **[Relationship to non-standardized t-distribution](/P/nst-t)**
+- **[Probability density function](/P/t-pdf)**
+### Gamma distribution
+- *[Definition](/D/gam)*
+- **[Special case of Wishart distribution](/P/gam-wish)**
+- *[Standard gamma distribution](/D/sgam)*
+- **[Relationship to standard gamma distribution](/P/gam-sgam)**
+- **[Relationship to standard gamma distribution](/P/gam-sgam2)**
+- **[Scaling of a gamma random variable](/P/gam-scal)**
+- **[Probability density function](/P/gam-pdf)**
+- **[Moment-generating function](/P/gam-mgf)**
+- **[Cumulative distribution function](/P/gam-cdf)**
+- **[Quantile function](/P/gam-qf)**
+- **[Mean](/P/gam-mean)**
+- **[Median](/P/gam-med)**
+- **[Mode](/P/gam-mode)**
+- **[Variance](/P/gam-var)**
+- **[Logarithmic expectation](/P/gam-logmean)**
+- **[Expectation of x ln x](/P/gam-xlogx)**
+- **[Differential entropy](/P/gam-dent)**
+- **[Kullback-Leibler divergence](/P/gam-kl)**
+### Exponential distribution
+- *[Definition](/D/exp)*
+- **[Special case of gamma distribution](/P/exp-gam)**
+- **[Probability density function](/P/exp-pdf)**
+- **[Moment-generating function](/P/exp-mgf)**
+- **[Cumulative distribution function](/P/exp-cdf)**
+- **[Quantile function](/P/exp-qf)**
+- **[Mean](/P/exp-mean)**
+- **[Median](/P/exp-med)**
+- **[Mode](/P/exp-mode)**
+- **[Variance](/P/exp-var)**
+- **[Skewness](/P/exp-skew)**
+### Log-normal distribution
+- *[Definition](/D/lognorm)*
+- **[Probability density function](/P/lognorm-pdf)**
+- **[Cumulative distribution function](/P/lognorm-cdf)**
+- **[Quantile function](/P/lognorm-qf)**
+- **[Mean](/P/lognorm-mean)**
+- **[Median](/P/lognorm-med)**
+- **[Mode](/P/lognorm-mode)**
+- **[Variance](/P/lognorm-var)**
+- **[Product of independent log-normals](/P/lognorm-prodind)**
+- **[Geometric mean of independent log-normals](/P/lognorm-geomind)**
+### Chi-squared distribution
+- *[Definition](/D/chi2)*
+- **[Special case of gamma distribution](/P/chi2-gam)**
+- **[Probability density function](/P/chi2-pdf)**
+- **[Raw moments](/P/chi2-momraw)**
+### F-distribution
+- *[Definition](/D/f)*
+- **[Probability density function](/P/f-pdf)**
+### Beta distribution
+- *[Definition](/D/beta)*
+- **[Special case of Dirichlet distribution](/P/beta-dir)**
+- **[Relationship to chi-squared distribution](/P/beta-chi2)**
+- **[Relationship to F-distribution](/P/beta-f)**
+- **[Probability density function](/P/beta-pdf)**
+- **[Moment-generating function](/P/beta-mgf)**
+- **[Cumulative distribution function](/P/beta-cdf)**
+- **[Mean](/P/beta-mean)**
+- **[Median](/P/beta-med)**
+- **[Mode](/P/beta-mode)**
+- **[Variance](/P/beta-var)**
+### Wald distribution
+- *[Definition](/D/wald)*
+- **[Probability density function](/P/wald-pdf)**
+- **[Moment-generating function](/P/wald-mgf)**
+- **[Mean](/P/wald-mean)**
+- **[Variance](/P/wald-var)**
+- **[Skewness](/P/wald-skew)**
+- **[Method of moments](/P/wald-mome)**
+### ex-Gaussian distribution
+- *[Definition](/D/exg)*
+- **[Probability density function](/P/exg-pdf)**
+- **[Moment-generating function](/P/exg-mgf)**
+- **[Mean](/P/exg-mean)**
+- **[Variance](/P/exg-var)**
+- **[Skewness](/P/exg-skew)**
+- **[Method of moments](/P/exg-mome)**
+## Multivariate continuous distributions
+### Multivariate normal distribution
+- *[Definition](/D/mvn)*
+- **[Special case of matrix-normal distribution](/P/mvn-matn)**
+- **[Relationship to chi-squared distribution](/P/mvn-chi2)**
+- **[Probability density function](/P/mvn-pdf)**
+- **[Moment-generating function](/P/mvn-mgf)**
+- **[Mean](/P/mvn-mean)**
+- **[Mode](/P/mvn-mode)**
+- **[Covariance](/P/mvn-cov)**
+- **[Expectation of a quadratic form](/P/mvn-meanqf)**
+- **[Differential entropy](/P/mvn-dent)**
+- **[Mutual information](/P/mvn-mi)**
+- **[Kullback-Leibler divergence](/P/mvn-kl)**
+- **[Maximum entropy distribution](/P/mvn-maxent)**
+- **[Linear transformation](/P/mvn-ltt)**
+- **[Marginal distributions](/P/mvn-marg)**
+- **[Conditional distributions](/P/mvn-cond)**
+- **[Conditions for independence](/P/mvn-ind)**
+- **[Independence of products](/P/mvn-indprod)**
+- **[Drawing samples](/P/mvn-samp)**
+### Bivariate normal distribution
+- *[Definition](/D/bvn)*
+- **[Probability density function](/P/bvn-pdf)**
+- **[Probability density function in terms of correlation coefficient](/P/bvn-pdfcorr)**
+- **[Construction from standard normal distributions](/P/bvn-snorm)**
+- **[Mutual information](/P/bvn-mi)**
+- **[Linear combination](/P/bvn-lincomb)**
+### Multivariate t-distribution
+- *[Definition](/D/mvt)*
+- **[Probability density function](/P/mvt-pdf)**
+- **[Relationship to F-distribution](/P/mvt-f)**
+### Normal-gamma distribution
+- *[Definition](/D/ng)*
+- **[Special case of normal-Wishart distribution](/P/ng-nw)**
+- **[Probability density function](/P/ng-pdf)**
+- **[Mean](/P/ng-mean)**
+- **[Covariance](/P/ng-cov)**
+- **[Differential entropy](/P/ng-dent)**
+- **[Kullback-Leibler divergence](/P/ng-kl)**
+- **[Marginal distributions](/P/ng-marg)**
+- **[Conditional distributions](/P/ng-cond)**
+- **[Drawing samples](/P/ng-samp)**
+### Dirichlet distribution
+- *[Definition](/D/dir)*
+- **[Probability density function](/P/dir-pdf)**
+- **[Kullback-Leibler divergence](/P/dir-kl)**
+- **[Exceedance probabilities](/P/dir-ep)**
+## Matrix-variate continuous distributions
+### Matrix-normal distribution
+- *[Definition](/D/matn)*
+- **[Equivalence to multivariate normal distribution](/P/matn-mvn)**
+- **[Probability density function](/P/matn-pdf)**
+- **[Mean](/P/matn-mean)**
+- **[Covariance](/P/matn-cov)**
+- **[Differential entropy](/P/matn-dent)**
+- **[Kullback-Leibler divergence](/P/matn-kl)**
+- **[Transposition](/P/matn-trans)**
+- **[Linear transformation](/P/matn-ltt)**
+- **[Marginal distributions](/P/matn-marg)**
+- **[Redundancy of parameters](/P/matn-red)**
+- **[Redundancy of parameters](/P/matn-red2)**
+- **[Drawing samples](/P/matn-samp)**
+### Wishart distribution
+- *[Definition](/D/wish)*
+- **[Kullback-Leibler divergence](/P/wish-kl)**
+### Normal-Wishart distribution
+- *[Definition](/D/nw)*
+- **[Probability density function](/P/nw-pdf)**
+- **[Mean](/P/nw-mean)**
+
+# Chapter III: Statistical Models
+## Univariate normal data
+### Univariate Gaussian
+- *[Definition](/D/ug)*
+- **[Maximum likelihood estimation](/P/ug-mle)**
+- **[One-sample t-test](/P/ug-ttest1)**
+- **[Two-sample t-test](/P/ug-ttest2)**
+- **[Paired t-test](/P/ug-ttestp)**
+- **[F-test for equality of variances](/P/ug-fev)**
+- **[Power analysis for one-sample t-test](/P/ug-ttest1power)**
+- **[Conjugate prior distribution](/P/ug-prior)**
+- **[Posterior distribution](/P/ug-post)**
+- **[Log model evidence](/P/ug-lme)**
+- **[Accuracy and complexity](/P/ug-anc)**
+- **[Cross-validated log model evidence](/P/ug-cvlme)**
+- **[Cross-validated log Bayes factor](/P/ug-cvlbf)**
+### Univariate Gaussian with known variance
+- *[Definition](/D/ugkv)*
+- **[Maximum likelihood estimation](/P/ugkv-mle)**
+- **[One-sample z-test](/P/ugkv-ztest1)**
+- **[Two-sample z-test](/P/ugkv-ztest2)**
+- **[Paired z-test](/P/ugkv-ztestp)**
+- **[Conjugate prior distribution](/P/ugkv-prior)**
+- **[Posterior distribution](/P/ugkv-post)**
+- **[Log model evidence](/P/ugkv-lme)**
+- **[Accuracy and complexity](/P/ugkv-anc)**
+- **[Log Bayes factor](/P/ugkv-lbf)**
+- **[Expectation of log Bayes factor](/P/ugkv-lbfmean)**
+- **[Cross-validated log model evidence](/P/ugkv-cvlme)**
+- **[Cross-validated log Bayes factor](/P/ugkv-cvlbf)**
+- **[Expectation of cross-validated log Bayes factor](/P/ugkv-cvlbfmean)**
+### Analysis of variance
+- *[One-way ANOVA](/D/anova1)*
+- *[Treatment sum of squares](/D/trss)*
+- **[Ordinary least squares for one-way ANOVA](/P/anova1-ols)**
+- **[Sums of squares in one-way ANOVA](/P/anova1-pss)**
+- **[F-test for main effect in one-way ANOVA](/P/anova1-f)**
+- **[F-statistic in terms of OLS estimates](/P/anova1-fols)**
+- **[Reparametrization of one-way ANOVA](/P/anova1-repara)**
+- *[Two-way ANOVA](/D/anova2)*
+- *[Interaction sum of squares](/D/iass)*
+- **[Ordinary least squares for two-way ANOVA](/P/anova2-ols)**
+- **[Sums of squares in two-way ANOVA](/P/anova2-pss)**
+- **[Cochran's theorem for two-way ANOVA](/P/anova2-cochran)**
+- **[F-test for main effect in two-way ANOVA](/P/anova2-fme)**
+- **[F-test for interaction in two-way ANOVA](/P/anova2-fia)**
+- **[F-test for grand mean in two-way ANOVA](/P/anova2-fgm)**
+- **[F-statistics in terms of OLS estimates](/P/anova2-fols)**
+### Simple linear regression
+- *[Definition](/D/slr)*
+- **[Special case of multiple linear regression](/P/slr-mlr)**
+- **[Ordinary least squares](/P/slr-ols)**
+- **[Ordinary least squares](/P/slr-ols2)**
+- **[Expectation of estimates](/P/slr-olsmean)**
+- **[Variance of estimates](/P/slr-olsvar)**
+- **[Distribution of estimates](/P/slr-olsdist)**
+- **[Correlation of estimates](/P/slr-olscorr)**
+- **[Effects of mean-centering](/P/slr-meancent)**
+- *[Regression line](/D/regline)*
+- **[Regression line includes center of mass](/P/slr-comp)**
+- **[Projection of data point to regression line](/P/slr-proj)**
+- **[Sums of squares](/P/slr-sss)**
+- **[Partition of sums of squares](/P/slr-pss)**
+- **[Transformation matrices](/P/slr-mat)**
+- **[Weighted least squares](/P/slr-wls)**
+- **[Weighted least squares](/P/slr-wls2)**
+- **[Maximum likelihood estimation](/P/slr-mle)**
+- **[Maximum likelihood estimation](/P/slr-mle2)**
+- **[t-test for intercept parameter](/P/slr-tint)**
+- **[t-test for slope parameter](/P/slr-tslo)**
+- **[F-test for model comparison](/P/slr-fcomp)**
+- **[Sum of residuals is zero](/P/slr-ressum)**
+- **[Correlation with covariate is zero](/P/slr-rescorr)**
+- **[Residual variance in terms of sample variance](/P/slr-resvar)**
+- **[Correlation coefficient in terms of slope estimate](/P/slr-corr)**
+- **[Coefficient of determination in terms of correlation coefficient](/P/slr-rsq)**
+### Multiple linear regression
+- *[Definition](/D/mlr)*
+- **[Special case of general linear model](/P/mlr-glm)**
+- **[Ordinary least squares](/P/mlr-ols)**
+- **[Ordinary least squares](/P/mlr-ols2)**
+- **[Ordinary least squares](/P/mlr-ols3)**
+- **[Ordinary least squares for two regressors](/P/mlr-olstr)**
+- *[Total sum of squares](/D/tss)*
+- *[Explained sum of squares](/D/ess)*
+- *[Residual sum of squares](/D/rss)*
+- **[Total, explained and residual sum of squares](/P/mlr-pss)**
+- *[Estimation matrix](/D/emat)*
+- *[Projection matrix](/D/pmat)*
+- *[Residual-forming matrix](/D/rfmat)*
+- **[Estimation, projection and residual-forming matrix](/P/mlr-mat)**
+- **[Symmetry of projection and residual-forming matrix](/P/mlr-symm)**
+- **[Idempotence of projection and residual-forming matrix](/P/mlr-idem)**
+- **[Independence of estimated parameters and residuals](/P/mlr-ind)**
+- **[Distribution of OLS estimates, signal and residuals](/P/mlr-olsdist)**
+- **[Distribution of WLS estimates, signal and residuals](/P/mlr-wlsdist)**
+- **[Distribution of residual sum of squares](/P/mlr-rssdist)**
+- **[Weighted least squares](/P/mlr-wls)**
+- **[Weighted least squares](/P/mlr-wls2)**
+- **[Maximum likelihood estimation](/P/mlr-mle)**
+- **[Maximum log-likelihood](/P/mlr-mll)**
+- **[Log-likelihood ratio](/P/mlr-llr)**
+- *[t-contrast](/D/tcon)*
+- *[F-contrast](/D/fcon)*
+- **[Contrast-based t-test](/P/mlr-t)**
+- **[Contrast-based F-test](/P/mlr-f)**
+- **[t-test for single regressor](/P/mlr-tsingle)**
+- **[F-test for multiple regressors](/P/mlr-fomnibus)**
+- **[Deviance function](/P/mlr-dev)**
+- **[Akaike information criterion](/P/mlr-aic)**
+- **[Bayesian information criterion](/P/mlr-bic)**
+- **[Corrected Akaike information criterion](/P/mlr-aicc)**
+### Bayesian linear regression
+- **[Conjugate prior distribution](/P/blr-prior)**
+- **[Posterior distribution](/P/blr-post)**
+- **[Log model evidence](/P/blr-lme)**
+- **[Accuracy and complexity](/P/blr-anc)**
+- **[Deviance information criterion](/P/blr-dic)**
+- **[Maximum-a-posteriori estimation](/P/blr-map)**
+- **[Expression of posterior parameters using error terms](/P/blr-posterr)**
+- **[Posterior probability of alternative hypothesis](/P/blr-pp)**
+- **[Posterior credibility region excluding null hypothesis](/P/blr-pcr)**
+- **[Combined posterior distribution from independent data sets](/P/blr-postind)**
+- **[Log Bayes factor for comparison of two regression models](/P/blr-lbf)**
+### Bayesian linear regression with known covariance
+- **[Conjugate prior distribution](/P/blrkc-prior)**
+- **[Posterior distribution](/P/blrkc-post)**
+- **[Log model evidence](/P/blrkc-lme)**
+- **[Accuracy and complexity](/P/blrkc-anc)**
+## Multivariate normal data
+### Multivariate Gaussian
+- *[Bivariate normally distributed data](/D/bvn-data)*
+- *[Multivariate normally distributed data](/D/mvn-data)*
+- **[Maximum likelihood estimation (p = 2)](/P/bvn-mle)**
+- **[Maximum likelihood estimation (p > 2)](/P/mvn-mle)**
+### General linear model
+- *[Definition](/D/glm)*
+- **[Ordinary least squares](/P/glm-ols)**
+- **[Weighted least squares](/P/glm-wls)**
+- **[Maximum likelihood estimation](/P/glm-mle)**
+- **[Maximum log-likelihood](/P/glm-mll)**
+- **[Log-likelihood ratio](/P/glm-llr)**
+- **[Mutual information](/P/glm-mi)**
+- **[Log-likelihood ratio and estimated mutual information](/P/glm-llrmi)**
+### Transformed general linear model
+- *[Definition](/D/tglm)*
+- **[Derivation of the distribution](/P/tglm-dist)**
+- **[Equivalence of parameter estimates](/P/tglm-para)**
+### Inverse general linear model
+- *[Definition](/D/iglm)*
+- **[Derivation of the distribution](/P/iglm-dist)**
+- **[Best linear unbiased estimator](/P/iglm-blue)**
+- **[Equivalence of log-likelihood ratios](/P/iglm-llrs)**
+- *[Corresponding forward model](/D/cfm)*
+- **[Derivation of parameters](/P/cfm-para)**
+- **[Proof of existence](/P/cfm-exist)**
+### Multivariate Bayesian linear regression
+- **[Conjugate prior distribution](/P/mblr-prior)**
+- **[Posterior distribution](/P/mblr-post)**
+- **[Log model evidence](/P/mblr-lme)**
+## Count data
+### Binomial observations
+- *[Definition](/D/bin-data)*
+- **[Binomial test](/P/bin-test)**
+- **[Maximum likelihood estimation](/P/bin-mle)**
+- **[Maximum log-likelihood](/P/bin-mll)**
+- **[Maximum-a-posteriori estimation](/P/bin-map)**
+- **[Conjugate prior distribution](/P/bin-prior)**
+- **[Posterior distribution](/P/bin-post)**
+- **[Log model evidence](/P/bin-lme)**
+- **[Log Bayes factor](/P/bin-lbf)**
+- **[Posterior probability](/P/bin-pp)**
+- **[Cross-validated log model evidence](/P/bin-cvlme)**
+### Multinomial observations
+- *[Definition](/D/mult-data)*
+- **[Multinomial test](/P/mult-test)**
+- **[Maximum likelihood estimation](/P/mult-mle)**
+- **[Maximum log-likelihood](/P/mult-mll)**
+- **[Maximum-a-posteriori estimation](/P/mult-map)**
+- **[Conjugate prior distribution](/P/mult-prior)**
+- **[Posterior distribution](/P/mult-post)**
+- **[Log model evidence](/P/mult-lme)**
+- **[Log Bayes factor](/P/mult-lbf)**
+- **[Posterior probability](/P/mult-pp)**
+- **[Cross-validated log model evidence](/P/mult-cvlme)**
+### Poisson-distributed data
+- *[Definition](/D/poiss-data)*
+- **[Maximum likelihood estimation](/P/poiss-mle)**
+- **[Conjugate prior distribution](/P/poiss-prior)**
+- **[Posterior distribution](/P/poiss-post)**
+- **[Log model evidence](/P/poiss-lme)**
+### Poisson distribution with exposure values
+- *[Definition](/D/poissexp)*
+- **[Maximum likelihood estimation](/P/poissexp-mle)**
+- **[Conjugate prior distribution](/P/poissexp-prior)**
+- **[Posterior distribution](/P/poissexp-post)**
+- **[Log model evidence](/P/poissexp-lme)**
+## Frequency data
+### Beta-distributed data
+- *[Definition](/D/beta-data)*
+- **[Method of moments](/P/beta-mome)**
+### Dirichlet-distributed data
+- *[Definition](/D/dir-data)*
+- **[Maximum likelihood estimation](/P/dir-mle)**
+### Beta-binomial data
+- *[Definition](/D/betabin-data)*
+- **[Method of moments](/P/betabin-mome)**
+## Categorical data
+### Logistic regression
+- *[Definition](/D/logreg)*
+- **[Probability and log-odds](/P/logreg-pnlo)**
+- **[Log-odds and probability](/P/logreg-lonp)**
+
+# Chapter IV: Model Selection
+## Goodness-of-fit measures
+### Residual variance
+- *[Definition](/D/resvar)*
+- **[Maximum likelihood estimator is biased (p = 1)](/P/resvar-bias)**
+- **[Maximum likelihood estimator is biased (p > 1)](/P/resvar-biasp)**
+- **[Construction of unbiased estimator (p = 1)](/P/resvar-unb)**
+- **[Construction of unbiased estimator (p > 1)](/P/resvar-unbp)**
+### R-squared
+- *[Definition](/D/rsq)*
+- **[Derivation of R² and adjusted R²](/P/rsq-der)**
+- **[Relationship to residual variance](/P/rsq-resvar)**
+- **[Relationship to maximum log-likelihood](/P/rsq-mll)**
+- **[Statistical significance test for R²](/P/rsq-test)**
+- **[Distribution under null hypothesis](/P/rsq-dist)**
+- **[Mean/mode/median under null hypothesis](/P/rsq-mmm)**
+- **[Variance under null hypothesis](/P/rsq-var)**
+### F-statistic
+- *[Definition](/D/fstat)*
+- **[Relationship to coefficient of determination](/P/fstat-rsq)**
+- **[Relationship to maximum log-likelihood](/P/fstat-mll)**
+### Signal-to-noise ratio
+- *[Definition](/D/snr)*
+- **[Relationship to coefficient of determination](/P/snr-rsq)**
+- **[Relationship to maximum log-likelihood](/P/snr-mll)**
+## Classical information criteria
+### Akaike information criterion
+- *[Definition](/D/aic)*
+- *[Corrected AIC](/D/aicc)*
+- **[Corrected AIC and uncorrected AIC](/P/aicc-aic)**
+- **[Corrected AIC and maximum log-likelihood](/P/aicc-mll)**
+### Bayesian information criterion
+- *[Definition](/D/bic)*
+- **[Derivation](/P/bic-der)**
+### Deviance information criterion
+- *[Definition](/D/dic)*
+- *[Deviance](/D/dev)*
+## Bayesian model selection
+### Model evidence
+- *[Definition](/D/me)*
+- **[Derivation](/P/me-der)**
+- *[Log model evidence](/D/lme)*
+- **[Derivation of the log model evidence](/P/lme-der)**
+- **[Expression using prior and posterior](/P/lme-pnp)**
+- **[Partition into accuracy and complexity](/P/lme-anc)**
+- **[Subtraction of mean from LMEs](/P/lme-mean)**
+- *[Uniform-prior log model evidence](/D/uplme)*
+- *[Cross-validated log model evidence](/D/cvlme)*
+- *[Empirical Bayesian log model evidence](/D/eblme)*
+- *[Variational Bayesian log model evidence](/D/vblme)*
+### Family evidence
+- *[Definition](/D/fe)*
+- **[Derivation](/P/fe-der)**
+- *[Log family evidence](/D/lfe)*
+- **[Derivation of the log family evidence](/P/lfe-der)**
+- **[Calculation from log model evidences](/P/lfe-lme)**
+- **[Approximation of log family evidences](/P/lfe-approx)**
+### Bayes factor
+- *[Definition](/D/bf)*
+- **[Transitivity](/P/bf-trans)**
+- **[Computation using Savage-Dickey density ratio](/P/bf-sddr)**
+- **[Computation using encompassing prior method](/P/bf-ep)**
+- *[Encompassing model](/D/encm)*
+- *[Log Bayes factor](/D/lbf)*
+- **[Derivation of the log Bayes factor](/P/lbf-der)**
+- **[Calculation from log model evidences](/P/lbf-lme)**
+### Posterior model probability
+- *[Definition](/D/pmp)*
+- **[Derivation](/P/pmp-der)**
+- **[Calculation from Bayes factors](/P/pmp-bf)**
+- **[Calculation from log Bayes factor](/P/pmp-lbf)**
+- **[Calculation from log model evidences](/P/pmp-lme)**
+### Bayesian model averaging
+- *[Definition](/D/bma)*
+- **[Derivation](/P/bma-der)**
+- **[Calculation from log model evidences](/P/bma-lme)**

--- a/book_content.md
+++ b/book_content.md
@@ -33,18 +33,18 @@
 - **[Probability under exclusivity](/P/prob-exc)**
 ### Probability axioms
 - *[Axioms of probability](/D/prob-ax)*
-- **[Monotonicity of probability](/P/prob-mon)**
-- **[Monotonicity of probability](/P/prob-mon2)**
-- **[Probability of the empty set](/P/prob-emp)**
-- **[Probability of the empty set](/P/prob-emp2)**
+- **[Monotonicity of probability](/P/prob-mon)** (1) 
+- **[Monotonicity of probability](/P/prob-mon2)** (2) 
+- **[Probability of the empty set](/P/prob-emp)** (1) 
+- **[Probability of the empty set](/P/prob-emp2)** (2) 
 - **[Probability of the complement](/P/prob-comp)**
 - **[Range of probability](/P/prob-range)**
 - **[Addition law of probability](/P/prob-add)**
 - **[Bonferroni's inequality](/P/bonf-ineq)**
 - **[Boole's inequality](/P/bool-ineq)**
 - **[Law of total probability](/P/prob-tot)**
-- **[Probability of exhaustive events](/P/prob-exh)**
-- **[Probability of exhaustive events](/P/prob-exh2)**
+- **[Probability of exhaustive events](/P/prob-exh)** (1) 
+- **[Probability of exhaustive events](/P/prob-exh2)** (2) 
 ### Probability distributions
 - *[Probability distribution](/D/dist)*
 - *[Joint distribution](/D/dist-joint)*
@@ -227,9 +227,9 @@
 - **[Relation to joint and conditional differential entropy](/P/cmi-jcde)**
 ### Kullback-Leibler divergence
 - *[Definition](/D/kl)*
-- **[Non-negativity](/P/kl-nonneg)**
-- **[Non-negativity](/P/kl-nonneg2)**
-- **[Non-negativity](/P/kl-nonneg3)**
+- **[Non-negativity](/P/kl-nonneg)** (1) 
+- **[Non-negativity](/P/kl-nonneg2)** (2) 
+- **[Non-negativity](/P/kl-nonneg3)** (3) 
 - **[Non-symmetry](/P/kl-nonsymm)**
 - **[Convexity](/P/kl-conv)**
 - **[Additivity for independent distributions](/P/kl-add)**
@@ -395,9 +395,9 @@
 - *[Definition](/D/norm)*
 - **[Special case of multivariate normal distribution](/P/norm-mvn)**
 - *[Standard normal distribution](/D/snorm)*
-- **[Relationship to standard normal distribution](/P/norm-snorm)**
-- **[Relationship to standard normal distribution](/P/norm-snorm2)**
-- **[Relationship to standard normal distribution](/P/norm-snorm3)**
+- **[Relationship to standard normal distribution](/P/norm-snorm)** (1) 
+- **[Relationship to standard normal distribution](/P/norm-snorm2)** (2) 
+- **[Relationship to standard normal distribution](/P/norm-snorm3)** (3) 
 - **[Relationship to chi-squared distribution](/P/norm-chi2)**
 - **[Relationship to t-distribution](/P/norm-t)**
 - **[Gaussian integral](/P/norm-gi)**
@@ -430,8 +430,8 @@
 - *[Definition](/D/gam)*
 - **[Special case of Wishart distribution](/P/gam-wish)**
 - *[Standard gamma distribution](/D/sgam)*
-- **[Relationship to standard gamma distribution](/P/gam-sgam)**
-- **[Relationship to standard gamma distribution](/P/gam-sgam2)**
+- **[Relationship to standard gamma distribution](/P/gam-sgam)** (1) 
+- **[Relationship to standard gamma distribution](/P/gam-sgam2)** (2) 
 - **[Scaling of a gamma random variable](/P/gam-scal)**
 - **[Probability density function](/P/gam-pdf)**
 - **[Moment-generating function](/P/gam-mgf)**
@@ -564,8 +564,8 @@
 - **[Transposition](/P/matn-trans)**
 - **[Linear transformation](/P/matn-ltt)**
 - **[Marginal distributions](/P/matn-marg)**
-- **[Redundancy of parameters](/P/matn-red)**
-- **[Redundancy of parameters](/P/matn-red2)**
+- **[Redundancy of parameters](/P/matn-red)** (1) 
+- **[Redundancy of parameters](/P/matn-red2)** (2) 
 - **[Drawing samples](/P/matn-samp)**
 ### Wishart distribution
 - *[Definition](/D/wish)*
@@ -626,8 +626,8 @@
 ### Simple linear regression
 - *[Definition](/D/slr)*
 - **[Special case of multiple linear regression](/P/slr-mlr)**
-- **[Ordinary least squares](/P/slr-ols)**
-- **[Ordinary least squares](/P/slr-ols2)**
+- **[Ordinary least squares](/P/slr-ols)** (1) 
+- **[Ordinary least squares](/P/slr-ols2)** (2) 
 - **[Expectation of estimates](/P/slr-olsmean)**
 - **[Variance of estimates](/P/slr-olsvar)**
 - **[Distribution of estimates](/P/slr-olsdist)**
@@ -639,10 +639,10 @@
 - **[Sums of squares](/P/slr-sss)**
 - **[Partition of sums of squares](/P/slr-pss)**
 - **[Transformation matrices](/P/slr-mat)**
-- **[Weighted least squares](/P/slr-wls)**
-- **[Weighted least squares](/P/slr-wls2)**
-- **[Maximum likelihood estimation](/P/slr-mle)**
-- **[Maximum likelihood estimation](/P/slr-mle2)**
+- **[Weighted least squares](/P/slr-wls)** (1) 
+- **[Weighted least squares](/P/slr-wls2)** (2) 
+- **[Maximum likelihood estimation](/P/slr-mle)** (1) 
+- **[Maximum likelihood estimation](/P/slr-mle2)** (2) 
 - **[t-test for intercept parameter](/P/slr-tint)**
 - **[t-test for slope parameter](/P/slr-tslo)**
 - **[F-test for model comparison](/P/slr-fcomp)**
@@ -654,9 +654,9 @@
 ### Multiple linear regression
 - *[Definition](/D/mlr)*
 - **[Special case of general linear model](/P/mlr-glm)**
-- **[Ordinary least squares](/P/mlr-ols)**
-- **[Ordinary least squares](/P/mlr-ols2)**
-- **[Ordinary least squares](/P/mlr-ols3)**
+- **[Ordinary least squares](/P/mlr-ols)** (1) 
+- **[Ordinary least squares](/P/mlr-ols2)** (2) 
+- **[Ordinary least squares](/P/mlr-ols3)** (3) 
 - **[Ordinary least squares for two regressors](/P/mlr-olstr)**
 - *[Total sum of squares](/D/tss)*
 - *[Explained sum of squares](/D/ess)*
@@ -672,8 +672,8 @@
 - **[Distribution of OLS estimates, signal and residuals](/P/mlr-olsdist)**
 - **[Distribution of WLS estimates, signal and residuals](/P/mlr-wlsdist)**
 - **[Distribution of residual sum of squares](/P/mlr-rssdist)**
-- **[Weighted least squares](/P/mlr-wls)**
-- **[Weighted least squares](/P/mlr-wls2)**
+- **[Weighted least squares](/P/mlr-wls)** (1) 
+- **[Weighted least squares](/P/mlr-wls2)** (2) 
 - **[Maximum likelihood estimation](/P/mlr-mle)**
 - **[Maximum log-likelihood](/P/mlr-mll)**
 - **[Log-likelihood ratio](/P/mlr-llr)**

--- a/construct_toc.py
+++ b/construct_toc.py
@@ -1,0 +1,109 @@
+def reconstruct_toc(markdown_content):
+    """
+    Backtransforms a simplified markdown Table of Contents (with unnumbered sections/subsections)
+    into the original I/ToC.md format, using internal counters for numbering.
+
+    Args:
+        markdown_content (str): The content of the simplified structure.md file.
+
+    Returns:
+        str: The reconstructed I/ToC.md content.
+    """
+    final_output_lines = []
+
+    # Helper to convert integer to Roman numeral
+    def to_roman(num):
+        romans = {
+            1: 'I', 2: 'II', 3: 'III', 4: 'IV',
+            5: 'V', 9: 'IX', 10: 'X', 40: 'XL',
+            50: 'L', 90: 'XC', 100: 'C', 400: 'CD',
+            500: 'D', 900: 'CM', 1000: 'M'
+        }
+        result = ""
+        # Iterate in descending order of values to build the Roman numeral
+        for value, symbol in sorted(romans.items(), reverse=True):
+            while num >= value:
+                result += symbol
+                num -= value
+        return result
+
+    # Initial fixed lines matching I/ToC.md template
+    final_output_lines.extend([
+        "---",
+        "layout: page",
+        "title: \"Table of Contents\"",
+        "---",
+        "", # Blank line
+        "", # Blank line
+        "**[Proofs](/P/-temp-)** are printed in **bold** – *[Definitions](/D/-temp-)* are set in *italics* <br>",
+        "**Proofs**: [by Number](/I/PbN), [by Topic](/I/PbT) – *Definitions*:  [by Number](/I/DbN), [by Topic](/D/DbT) <br>",
+        "<u>Specials:</u> [General Theorems](/S/ChI), [Probability Distributions](/S/ChII), [Statistical Models](/S/ChIII), [Model Selection Criteria](/S/ChIV) <br>",
+        "", # First <br> before Chapter I h3
+        "", # Second <br> before Chapter I h3
+    ])
+
+    chapter_index = 0
+    current_section_num = 0
+    current_subsection_num = 0
+    current_subsub_num = 0
+
+    lines = markdown_content.strip().splitlines()
+
+    for i, line_str in enumerate(lines):
+        line = line_str.strip()
+
+        if line.startswith("# Chapter "):
+            if chapter_index > 0:
+                final_output_lines.extend(
+                    [""]*2
+                )
+            final_output_lines.append("<br>") # Add <br> before subsequent chapters
+
+            chapter_index += 1
+            roman_chapter = to_roman(chapter_index)
+            chapter_title = line[len("# Chapter ") + line.find(': ') - len("Chapter ")-1 :].strip() # Extracts "General Theorems" etc.
+            final_output_lines.append(f'<h3 id="{chapter_title}">Chapter {roman_chapter}: {chapter_title}</h3>')
+            final_output_lines.append("") # Always a blank line after an h3
+
+            # Reset counters for a new chapter
+            current_section_num = 0
+            current_subsection_num = 0
+            current_subsub_num = 0
+
+        elif line.startswith("## "):
+            # Reset sub-subsection counter when a new section starts
+            current_subsection_num = 0
+            current_subsub_num = 0
+
+            current_section_num += 1
+            section_title = line[len("## "):].strip()
+            final_output_lines.append("   ") # Indented blank line after section <p> tag, matching original
+            final_output_lines.append(f'{current_section_num}. <p id="{section_title}">{section_title}</p>')
+
+        elif line.startswith("### "):
+            # Reset sub-subsection counter when a new subsection starts
+            current_subsub_num = 0
+
+            current_subsection_num += 1
+            subsection_title = line[len("### "):].strip() # Extracts "Random experiments"
+            # In the original, the p id is the title, and the text below is also the title
+            final_output_lines.append("   ")
+            final_output_lines.append(f'   <p id="{subsection_title}"></p>')
+            final_output_lines.append(f'   {current_section_num}.{current_subsection_num}. {subsection_title} <br>')
+
+        elif line.startswith("- "):
+            current_subsub_num += 1
+            item_content = line[len("- "):] # Get content after "- "
+            final_output_lines.append(f'   &emsp;&ensp; {current_section_num}.{current_subsection_num}.{current_subsub_num}. {item_content} <br>')
+
+    return "\n".join(final_output_lines)
+
+if __name__ == '__main__':
+
+    with open('./structure.md', 'r') as f:
+        md = f.read()
+
+    with open("./I/ToC.md", 'w') as f:
+        f.write(
+            reconstruct_toc(md)
+        )

--- a/construct_toc.py
+++ b/construct_toc.py
@@ -36,7 +36,7 @@ def reconstruct_toc(markdown_content):
         "", # Blank line
         "", # Blank line
         "**[Proofs](/P/-temp-)** are printed in **bold** – *[Definitions](/D/-temp-)* are set in *italics* <br>",
-        "**Proofs**: [by Number](/I/PbN), [by Topic](/I/PbT) – *Definitions*:  [by Number](/I/DbN), [by Topic](/D/DbT) <br>",
+        "**Proofs**: [by Number](/I/PbN), [by Topic](/I/PbT) – *Definitions*:  [by Number](/I/DbN), [by Topic](/I/DbT) <br>",
         "<u>Specials:</u> [General Theorems](/S/ChI), [Probability Distributions](/S/ChII), [Statistical Models](/S/ChIII), [Model Selection Criteria](/S/ChIV) <br>",
         "", # First <br> before Chapter I h3
         "", # Second <br> before Chapter I h3

--- a/construct_toc.py
+++ b/construct_toc.py
@@ -100,7 +100,7 @@ def reconstruct_toc(markdown_content):
 
 if __name__ == '__main__':
 
-    with open('./structure.md', 'r') as f:
+    with open('./book_content.md', 'r') as f:
         md = f.read()
 
     with open("./I/ToC.md", 'w') as f:


### PR DESCRIPTION
I converted the ToC to a markdown document which makes it easier to insert new definition and proofs without being bothered by manual renumbering. 
New content is added to `book_content.md` and running `construct_toc.py` compiles the `I/ToC.md`.

The ToC in this PR was recompiled, which removed some numbering errors.

- [ ] Wiki needs to be updated, if PR is merged
